### PR TITLE
Add a configurable `redirect_uri` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Please review the [Pocket API](http://getpocket.com/developer/docs/overview) for
 let getPocket = require('pocket-api')
 
 let consumer_key = 'your consumer_key';
+let consumer_key = 'your redirect_uri';  // eg. 'localhost:8000/redirect'
 
-let pocket = new getPocket(consumer_key);
+let pocket = new getPocket(consumer_key, redirect_uri);
 
 pocket.getRequestToken()
 .then(response => {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 const got = require('got')
 
 const PocketAPI = class {
-	constructor (consumer_key) {
+	constructor (consumer_key, redirect_uri = 'pocketapp1234:authorizationFinished') {
 		this.consumer_key = consumer_key
+		this.redirect_uri = redirect_uri
 		this.config = {
 			pocketUrl: {
 				request: 'https://getpocket.com/v3/oauth/request',
@@ -45,7 +46,7 @@ const PocketAPI = class {
 		let token
 		const values = {
 			consumer_key: this.consumer_key,
-			redirect_uri: 'pocketapp1234:authorizationFinished'
+			redirect_uri: this.redirect_uri,
 		}
 
 		const options = this.setOptions(values, this.config.pocketUrl.request)
@@ -103,7 +104,6 @@ const PocketAPI = class {
 		const access = {
 			consumer_key: this.consumer_key,
 			access_token: this.access_token,
-			redirect_uri: 'pocketapp1234:authorizationFinished'
 		}
 
 		const values = { ...access, ...params }


### PR DESCRIPTION
With general utility in mind, it’s unlikely that most apps will be able
to use `pocketapp1234:authorizationFinished` as their redirect URI. By
adding a `redirect_uri` parameter to the constructor, folks can set the
internal URI to match whatever they pass to Pocket during
authentication.