### PR TITLE
Fix some bugs related to `request_token` and `access_token`

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,12 +57,12 @@ const PocketAPI = class {
 			throw new Error(e)
 		}
 
+		token = JSON.parse(response.body)
+		this.request_token = token.code;
+
 		if (callback) {
-			token = JSON.parse(response.body)
 			return callback(token.code)
 		}
-
-		token = JSON.parse(response.body)
 		return token.code
 	}
 
@@ -87,14 +87,12 @@ const PocketAPI = class {
 			throw new Error(e)
 		}
 
+		token = JSON.parse(response.body)
+		this.access_token = token.access_token
+
 		if (callback) {
-			token = JSON.parse(response.body)
-			this.access_token = token.code
 			return callback(token)
 		}
-
-		token = JSON.parse(response.body)
-		this.access_token = token.code
 		return token
 	}
 


### PR DESCRIPTION
1. `this.request_token` was not being updated from `getRequestToken()`,
   which caused subsequent calls to `getAccessToken()` to fail. I fixed
   it to update `this.request_token`, which mirrors how
   `getAccessToken()` updates the value of `this.access_token`.
2. Set `this.access_token` to the correct value. Prior to this PR, it
   was being updated to `token.code`, which is `undefined` in the access
   token response. The correct key is `token.access_token`.