### PR TITLE
Remove invalid option key

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const PocketAPI = class {
 			body: JSON.stringify(values),
 			url: endpoint,
 			method: method,
-			reponseType: 'json'
+			responseType: 'json'
 		}
 	}
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ const PocketAPI = class {
 			body: JSON.stringify(values),
 			url: endpoint,
 			method: method,
-			responseType: 'json'
 		}
 	}
 


### PR DESCRIPTION
There was a typo in the `responseType` key, which meant it was never getting interpreted by `got`. After fixing the typo, Pocket started returning `Response code 406 (Not Acceptable)`. Turns out they don’t support the `responseType` key after all 😅